### PR TITLE
Issue #1184: Signup sources with tags [PART 1]

### DIFF
--- a/app/Http/Repositories/MailChimpRepository.php
+++ b/app/Http/Repositories/MailChimpRepository.php
@@ -423,11 +423,11 @@ class MailChimpRepository implements MailChimpRepositoryInterface
         return $result;
     }
 
-    public function updateSubscriber(string $email, array $interests, string $listId, array $mergeFields) : bool
+    public function updateSubscriber(string $email, array $tags, string $listId, array $mergeFields) : bool
     {
         $arguments = [
             'email_address' => $email,
-            'interests' => $interests,
+            'tags' => $tags,
             'merge_fields' => $mergeFields
         ];
         $subscriberHash = $this->getSubscriberHashFromEmail($email);

--- a/app/Http/Repositories/MailChimpRepositoryInterface.php
+++ b/app/Http/Repositories/MailChimpRepositoryInterface.php
@@ -39,7 +39,7 @@ interface MailChimpRepositoryInterface
     public function getSignupLocationsFromApi(string $listId) : array;
     public function mailFromWordPress(string $email, string $subject, string $message) : bool;
     public function sendCampaign(string $campaignId) : bool;
-    public function subscribeMember(string $listId, string $email, array $interests, array $mergeFields) : ?SubscriberDto;
+    public function subscribeMember(string $listId, string $email, array $tags, array $mergeFields) : ?SubscriberDto;
     public function updateCampaignContentById(
         string $campaignId,
         string $content

--- a/app/Http/Services/MailChimpService.php
+++ b/app/Http/Services/MailChimpService.php
@@ -91,9 +91,9 @@ class MailChimpService implements MailChimpServiceInterface
         return $this->repository->mailFromWordPress($email, $subject, $message);
     }
 
-    public function subscribeMember(string $listId, string $email, array $interests, array $mergeFields) : ?Subscriber
+    public function subscribeMember(string $listId, string $email, array $tags, array $mergeFields) : ?Subscriber
     {
-        $subscriberDto = $this->repository->subscribeMember($listId, $email, $interests, $mergeFields);
+        $subscriberDto = $this->repository->subscribeMember($listId, $email, $tags, $mergeFields);
 
         if (empty($subscriberDto)) {
             return null;

--- a/app/Http/Services/MailChimpServiceInterface.php
+++ b/app/Http/Services/MailChimpServiceInterface.php
@@ -25,7 +25,7 @@ interface MailChimpServiceInterface
     public function getSegments(string $listId) : array;
     public function getSignupLocationsFromApi(string $listId) : array;
     public function mailFromWordPress(string $email, string $subject, string $message) : bool;
-    public function subscribeMember(string $listId, string $email, array $interests, array $mergeFields) : ?Subscriber;
+    public function subscribeMember(string $listId, string $email, array $tags, array $mergeFields) : ?Subscriber;
     public function updateMailChimpSettingsInWordPress(string $key) : bool;
     public function updateSubscriber(string $email, array $interests, string $listId, array $mergeFields) : bool;
     public function updateSubscriberMergeTag(string $email, string $listId, string $mergeTag, $mergeTagValue) : bool;

--- a/tests/app/Http/Repositories/MailChimpRepositoryTest.php
+++ b/tests/app/Http/Repositories/MailChimpRepositoryTest.php
@@ -181,7 +181,7 @@ class MailChimpRepositoryTest extends TestCase
     public function testSubscribeMember_returnsArray()
     {
         $dto = new SubscriberDto($this->subscriber);
-        $interestArray = [];
+        $tagsArray = [];
         $mergeFields = [];
         $email = 'al@whereby.us';
         $listId = '1234';
@@ -191,7 +191,7 @@ class MailChimpRepositoryTest extends TestCase
             ->method('post')
             ->willReturn($this->subscriber);
 
-        $actualResults = $this->repository->subscribeMember($listId, $email, $interestArray, $mergeFields);
+        $actualResults = $this->repository->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertEquals($dto, $actualResults);
     }
@@ -199,7 +199,7 @@ class MailChimpRepositoryTest extends TestCase
     public function testSubscribeMemberWithMergeTag_returnsArray()
     {
         $dto = new SubscriberDto($this->subscriber);
-        $interestArray = [];
+        $tagsArray = [];
         $mergeFields = ['FNAME' => 'Amy'];
         $email = 'al@whereby.us';
         $listId = '1234';
@@ -209,7 +209,7 @@ class MailChimpRepositoryTest extends TestCase
             ->method('post')
             ->willReturn($this->subscriber);
 
-        $actualResults = $this->repository->subscribeMember($listId, $email, $interestArray, $mergeFields);
+        $actualResults = $this->repository->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertEquals($dto, $actualResults);
     }
@@ -219,14 +219,14 @@ class MailChimpRepositoryTest extends TestCase
     {
         $listId = '393j3j3';
         $email = 'test@whereby.us';
-        $interests = [];
+        $tagsArray = [];
         $mergeFields = [];
         $this->mailchimp
             ->expects($this->once())
             ->method('post')
             ->will($this->throwException(new \Exception()));
 
-        $actualResults = $this->repository->subscribeMember($listId, $email, $interests, $mergeFields);
+        $actualResults = $this->repository->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertNull($actualResults);
     }
@@ -235,7 +235,7 @@ class MailChimpRepositoryTest extends TestCase
     {
         $listId = '29292j2j';
         $email = 'test@whereby.us';
-        $interests = [];
+        $tagsArray = [];
         $mergeFields = [];
 
         $this->mailchimp
@@ -243,7 +243,7 @@ class MailChimpRepositoryTest extends TestCase
             ->method('post')
             ->willReturn(false);
 
-        $actualResults = $this->repository->subscribeMember($listId, $email, $interests, $mergeFields);
+        $actualResults = $this->repository->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertNull($actualResults);
     }
@@ -251,7 +251,7 @@ class MailChimpRepositoryTest extends TestCase
     {
         $listId = '29292j2j';
         $email = 'test@whereby.us';
-        $interests = [];
+        $tagsArray = [];
         $mergeFields = [];
         $apiResults = [
             'details' => 'I am an error message',
@@ -263,7 +263,7 @@ class MailChimpRepositoryTest extends TestCase
             ->method('post')
             ->willReturn($apiResults);
 
-        $actualResults = $this->repository->subscribeMember($listId, $email, $interests, $mergeFields);
+        $actualResults = $this->repository->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertNull($actualResults);
     }

--- a/tests/app/Http/Services/MailChimpServiceTest.php
+++ b/tests/app/Http/Services/MailChimpServiceTest.php
@@ -137,16 +137,16 @@ class MailChimpServiceTest extends TestCase
         $listId = '191929j4j4';
         $dto = new SubscriberDto();
         $email = 'test@whereby.us';
-        $interests = [];
+        $tagsArray = [];
         $mergeFields = [];
         $member = new Subscriber($dto);
 
         $this->repository->expects($this->once())
             ->method('subscribeMember')
-            ->with($listId, $email, $interests, $mergeFields)
+            ->with($listId, $email, $tagsArray, $mergeFields)
             ->willReturn($dto);
 
-        $actualResults = $this->service->subscribeMember($listId, $email, $interests, $mergeFields);
+        $actualResults = $this->service->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertEquals($member, $actualResults);
     }
@@ -155,15 +155,15 @@ class MailChimpServiceTest extends TestCase
     {
         $listId = '1ij2j22';
         $email = 'test@whereby.us';
-        $interests = [];
+        $tagsArray = [];
         $mergeFields = [];
 
         $this->repository->expects($this->once())
             ->method('subscribeMember')
-            ->with($listId, $email, $interests)
+            ->with($listId, $email, $tagsArray)
             ->willReturn(null);
 
-        $actualResults = $this->service->subscribeMember($listId, $email, $interests, $mergeFields);
+        $actualResults = $this->service->subscribeMember($listId, $email, $tagsArray, $mergeFields);
 
         $this->assertNull($actualResults);
     }


### PR DESCRIPTION
Part 1: Changed `$interests` param to `$tags` within the `subscriberMember` function